### PR TITLE
[collections] add charmed-k8s initial collections.

### DIFF
--- a/collections/charmed-k8s.yaml
+++ b/collections/charmed-k8s.yaml
@@ -1,0 +1,51 @@
+collections:
+
+  etcd:
+    batch-size: 10000
+    run-every: 5s
+    exit-codes: 0
+    store: database
+    database:
+      map-values:
+        field-separator: " "
+        fields:
+          - name: unit
+            type: string
+            field-index: 0
+          - name: metric
+            type: string
+            field-index: 1
+          - name: value
+            type: int
+            field-index: 2
+    script: |
+      #!/bin/bash
+      for unit in $(juju status --format=json | jq -r '.applications."etcd".units | keys[]'); do
+        juju run --unit $unit "sudo curl -Ss -k --cert /var/snap/etcd/common/server.crt --key /var/snap/etcd/common/server.key https://localhost:2379/metrics" -o json | sed 's/#.*//' | awk -v unit=$unit 'NF { print unit " " $0; }';
+      done
+
+  kubeapi_server:
+    batch-size: 10000
+    run-every: 5s
+    exit-codes: 0
+    store: database
+    database:
+      map-values:
+        field-separator: " "
+        fields:
+          - name: metric
+            type: string
+            field-index: 0
+          - name: value
+            type: int
+            field-index: 1
+    script: |
+      #!/bin/bash
+      $(kubectl apply -f https://gist.githubusercontent.com/brettmilford/17fb21bfc3e81204822c445e83dcab19/raw/318aaaef000f6f244fccc601689661c03e2f9dcd/metrics-role.yaml  > /dev/null 2>&1)
+
+      CLUSTER_NAME="juju-cluster"
+      APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
+      TOKEN=$(kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='default')].data.token}"|base64 --decode)
+
+      curl --fail -s -X GET "${APISERVER}/metrics" --header "Authorization: Bearer $TOKEN" --insecure | sed 's/#.*//' | grep -v -i nan | awk 'NF>=2{ print $0; }'
+      exit $?

--- a/config.go
+++ b/config.go
@@ -64,6 +64,7 @@ type Collection struct {
 	Command   string   `yaml:"command"`
 	RunEvery  string   `yaml:"run-every" default:"0s"`
 	Timeout   string   `yaml:"timeout" default:"0s"`
+	BatchSize int      `yaml:"batch-size" default:"1"`
 	RunOnce   bool     `yaml:"run-once" default:"false"`
 	Script    string   `yaml:"script"`
 	ExitCodes string   `yaml:"exit-codes" default:"any"`


### PR DESCRIPTION
This commit adds a new collection for charmed-k8s, that will gather metrics for:

1) etcd: all the /metrics from each juju unit.

An example of the metrics gathered is:

sqlite> select * from etcd where metric like '%commit%' limit 3;
2020-11-27 14:31:01|||etcd/0|etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.001"}|143292|2
2020-11-27 14:31:01|||etcd/0|etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.002"}|143295|3
2020-11-27 14:31:01|||etcd/0|etcd_debugging_disk_backend_commit_rebalance_duration_seconds_bucket{le="0.004"}|143295|4

2) kubeapi-server metrics.

sqlite> select avg(value) from kubeapi_server where metric like '%request_duration%LIST%';
16.9428571428571

![image](https://user-images.githubusercontent.com/821670/100462310-d6201d80-30a8-11eb-93b4-dd33df22c745.png)

![image](https://user-images.githubusercontent.com/821670/100462349-e932ed80-30a8-11eb-875d-cd9a77f77f5b.png)
